### PR TITLE
Avoid "test" dir from lib-tk

### DIFF
--- a/stdlibs/fetch.py
+++ b/stdlibs/fetch.py
@@ -135,6 +135,9 @@ def regen(version: str) -> Set[str]:
         if p.name.startswith(("plat-", "lib-")):
             # 2.x platform dirs, or tk support
             for path in p.iterdir():
+                # lib-tk/test on 2.7
+                if path.name in ("test",):
+                    continue
                 # TODO plat-mac/lib-scriptpackages
                 if path.is_dir() and not path.name.startswith("lib-"):
                     names.append(path.name)

--- a/stdlibs/py.py
+++ b/stdlibs/py.py
@@ -526,7 +526,6 @@ module_names = frozenset(
         "tempfile",
         "terminalcommand",
         "termios",
-        "test",
         "textwrap",
         "this",
         "thread",

--- a/stdlibs/py2.py
+++ b/stdlibs/py2.py
@@ -449,7 +449,6 @@ module_names = frozenset(
         "tempfile",
         "terminalcommand",
         "termios",
-        "test",
         "textwrap",
         "this",
         "thread",

--- a/stdlibs/py27.py
+++ b/stdlibs/py27.py
@@ -415,7 +415,6 @@ module_names = frozenset(
         "tempfile",
         "terminalcommand",
         "termios",
-        "test",
         "textwrap",
         "this",
         "thread",


### PR DESCRIPTION
This now fully excludes the "test" top-level name, which on some distros is importable, but seems like a bad idea to include due to how generic and common it would be.