### PR TITLE
Ignore _missing_stdlib_info when testing

### DIFF
--- a/stdlibs/tests/__init__.py
+++ b/stdlibs/tests/__init__.py
@@ -36,6 +36,7 @@ class StdlibsTest(TestCase):
             name = module.with_suffix("").name
             name = name.split(".")[0]  # __phello__.foo
             if name.startswith("_sysconfigdata_") or name in (
+                "_missing_stdlib_info",
                 "sitecustomize",
                 "usercustomize",
             ):


### PR DESCRIPTION
This is no longer present in Python 3.15, see

https://bugzilla.redhat.com/show_bug.cgi?id=2417018 https://copr.fedorainfracloud.org/coprs/g/python/python3.15/package/python-stdlibs/